### PR TITLE
Added support for error codes.

### DIFF
--- a/cmd/customerd/handlers/customers_test.go
+++ b/cmd/customerd/handlers/customers_test.go
@@ -152,6 +152,14 @@ func TestGetCustomer(t *testing.T) {
 			teardownFunc:       tests.DBCallTeardownHelper,
 			expectedHTTPStatus: http.StatusInternalServerError,
 		},
+		{
+			testName:           "testGetCustomerErrNoRow",
+			url:                "/customers/notanumber",
+			shouldPass:         false,
+			setupFunc:          tests.DBCallNoExpectationsSetupHelper,
+			teardownFunc:       tests.DBCallTeardownHelper,
+			expectedHTTPStatus: http.StatusInternalServerError,
+		},
 	}
 
 	for _, tc := range tcs {

--- a/cmd/customerd/main.go
+++ b/cmd/customerd/main.go
@@ -60,26 +60,26 @@ func main() {
 	if err != nil {
 		logger.WithFields(log.Fields{
 			constants.ConfigFileName: *configFileName,
-			constants.AppError:       constants.UnableToOpenConfig,
+			constants.ErrorCode:      constants.UnableToOpenConfigErrorCode,
 			constants.ErrorDetail:    err.Error(),
-		}).Fatal("Error opening config file")
+		}).Fatal(constants.UnableToOpenConfig)
 	}
 	configs, err := config.LoadConfig(configFile)
 	if err != nil {
 		logger.WithFields(log.Fields{
 			constants.ConfigFileName: *configFileName,
-			constants.AppError:       constants.UnableToLoadConfig,
+			constants.ErrorCode:      constants.UnableToLoadConfigErrorCode,
 			constants.ErrorDetail:    err.Error(),
-		}).Fatal("Error loading config data")
+		}).Fatal(constants.UnableToLoadConfig)
 	}
 
 	secrets, err := config.LoadSecrets(*secretsDir)
 	if err != nil {
 		logger.WithFields(log.Fields{
 			constants.ConfigFileName: *secretsDir,
-			constants.AppError:       constants.UnableToLoadSecrets,
+			constants.ErrorCode:      constants.UnableToLoadSecretsErrorCode,
 			constants.ErrorDetail:    err.Error(),
-		}).Fatal("Error loading secrets data")
+		}).Fatal(constants.UnableToLoadSecrets)
 	}
 
 	loglevel, ok := configs["logLevel"]
@@ -100,17 +100,17 @@ func main() {
 	connStr, err := getDBConnectionStr(configs, secrets)
 	if err != nil {
 		logger.WithFields(log.Fields{
-			constants.AppError:    constants.UnableToGetDBConnStr,
+			constants.ErrorCode:   constants.UnableToGetDBConnStrErrorCode,
 			constants.ErrorDetail: err.Error(),
-		}).Fatal("Error constructing DB connection string")
+		}).Fatal(constants.UnableToGetDBConnStr)
 	}
 
 	db, err := sql.Open("mysql", connStr)
 	if err != nil {
 		logger.WithFields(log.Fields{
-			constants.AppError:    constants.UnableToOpenDBConn,
+			constants.ErrorCode:   constants.UnableToOpenDBConnErrorCode,
 			constants.ErrorDetail: err.Error(),
-		}).Fatal("Error opening DB connection")
+		}).Fatal(constants.UnableToOpenDBConn)
 	}
 	defer db.Close()
 
@@ -120,9 +120,9 @@ func main() {
 	customersHandler, err := handlers.New(db, logger)
 	if err != nil {
 		logger.WithFields(log.Fields{
-			constants.AppError:    constants.UnableToCreateHTTPHandler,
+			constants.ErrorCode:   constants.UnableToCreateHTTPHandlerErrorCode,
 			constants.ErrorDetail: err.Error(),
-		}).Fatal("Error creating 'customers' HTTP handler")
+		}).Fatal(constants.UnableToCreateHTTPHandler)
 	}
 	healthHandler := http.HandlerFunc(handlers.HealthFunc)
 

--- a/internal/customers/customer.go
+++ b/internal/customers/customer.go
@@ -29,10 +29,10 @@ type Customers struct {
 }
 
 // GetAllCustomers will return all customers known to the application
-func GetAllCustomers(db *sql.DB) (Customers, error) {
+func GetAllCustomers(db *sql.DB) (*Customers, error) {
 	results, err := db.Query("SELECT id, name, streetAddress, city, state, country FROM customer")
 	if err != nil {
-		return Customers{}, errors.Annotate(err, "error querying DB")
+		return &Customers{}, errors.Annotate(err, "error querying DB")
 	}
 
 	custs := Customers{}
@@ -46,13 +46,13 @@ func GetAllCustomers(db *sql.DB) (Customers, error) {
 			&customer.State,
 			&customer.Country)
 		if err != nil {
-			return Customers{}, errors.Annotate(err, "error scanning result set")
+			return &Customers{}, errors.Annotate(err, "error scanning result set")
 		}
 
 		custs.Customers = append(custs.Customers, &customer)
 	}
 
-	return custs, nil
+	return &custs, nil
 }
 
 // GetCustomer will return the customer identified by 'id' or a nil customer if there

--- a/internal/platform/constants/common_log_fields.go
+++ b/internal/platform/constants/common_log_fields.go
@@ -3,24 +3,36 @@ package constants
 //
 // **NOTE** When adding constants, please order them in alphabetical sequence
 //
+
+//
+// All constants below refer to the standard names for the various
+// fields used in log messages.
+//
 const (
-	// Application is a reference to the standard logging field "application"
-	AppError       string = "AppError"
 	Application    string = "Application"
 	ConfigFileName string = "ConfigFileName"
-	DBHost         string = "DBHost"
-	DBName         string = "DBName"
-	DBPort         string = "DBPort"
-	ErrorDetail    string = "ErrorDetail"
-	HostName       string = "HostName"
-	LogLevel       string = "LogLevel"
-	Method         string = "HTTPMethod"
-	Path           string = "URLPath"
-	Port           string = "Port"
+
+	DBHost string = "DBHost"
+	DBName string = "DBName"
+	DBPort string = "DBPort"
+
+	ErrorCode   string = "ErrorCode"
+	ErrorDetail string = "ErrorDetail"
+
+	HostName   string = "HostName"
+	HTTPStatus string = "HTTPStatus"
+
+	LogLevel string = "LogLevel"
+	Method   string = "HTTPMethod"
+
+	Path string = "URLPath"
+	Port string = "Port"
+
 	RemoteAddr     string = "RemoteAddr"
 	ServiceName    string = "ServiceName"
 	SecretsDirName string = "SecretsDirName"
-	TestName       string = "TestName"
+
+	TestName string = "TestName"
 )
 
 const (

--- a/internal/platform/constants/errors.go
+++ b/internal/platform/constants/errors.go
@@ -4,6 +4,10 @@ package constants
 //	1.	Refactor into errors with text and numeric code?
 
 const (
+	//
+	// Miscellaneous errors
+	//
+
 	// UnableToOpenConfig indicates there was a problem opening the configuration file
 	UnableToOpenConfig = "Unable to open configuration file"
 	// UnableToGetConfig indicates there was a problem obtaining the application configuration
@@ -19,12 +23,62 @@ const (
 	UnableToOpenDBConn = "Unable to open DB connection"
 	// DBRowScanError indicates results from DB query could not be processed
 	DBRowScanError = "DB resultset processing failed"
-
-	// UnableToCreateHTTPHandler indications that there was a problem creating an http handler
-	UnableToCreateHTTPHandler = "Unable to create HTTP handler"
 	// DBQueryError indications that there was a problem executing a DB query operation
 	DBQueryError = "DB query failed"
 
+	// UnableToCreateHTTPHandler indications that there was a problem creating an http handler
+	UnableToCreateHTTPHandler = "Unable to create HTTP handler"
+
 	// JSONMarshalingError indicates that there was a problem un/marshaling JSON
 	JSONMarshalingError = "JSON Marshaling Error"
+	// MalformedURL indicates there was a problem with the structure of the URL
+	MalformedURL = "Malformed URL"
+
+	//
+	// Customer related error codes start at 1000 and go to 1999
+	//
+
+	// CustTypeConversionError indicates that the payload returned from GET /customers/{id} could
+	// not be converted to either a Customers (/customers) or Customer (/customers/{id}) type
+	CustTypeConversionError = "Unable to convert payload to Customer(s) type"
+	// CustGETError indicates that GET /customers or GET /customers/{id} failed in some way
+	CustGETError = "GET /customers or GET /customers/{id} failed"
+)
+
+const (
+	//
+	// Misc related error codes start at 0 and go to 99
+	//
+
+	// UnableToOpenConfigErrorCode is the error code associated with UnableToOpenConfig
+	UnableToOpenConfigErrorCode = iota
+	// UnableToGetConfigErrorCode is the error code associated with UnableToGetConfig
+	UnableToGetConfigErrorCode
+	// UnableToLoadConfigErrorCode is the error code associated with UnableToLoadConfig
+	UnableToLoadConfigErrorCode
+	// UnableToLoadSecretsErrorCode is the error code associated with UnableToLoadSecrets
+	UnableToLoadSecretsErrorCode
+	// UnableToGetDBConnStrErrorCode is the error code associated with UnableToGetDBConnStr
+	UnableToGetDBConnStrErrorCode
+	// UnableToOpenDBConnErrorCode is the error code associated with UnableToOpenDBConn
+	UnableToOpenDBConnErrorCode
+	// DBRowScanErrorCode is the error code associated with DBRowScan
+	DBRowScanErrorCode
+	// DBQueryErrorCode is the error code associated with DBQueryError
+	DBQueryErrorCode
+	// UnableToCreateHTTPHandlerErrorCode is the error code associated with UnableToCreateHTTPHandler
+	UnableToCreateHTTPHandlerErrorCode
+	// JSONMarshalingErrorCode is the error code associated with JSONMarshaling
+	JSONMarshalingErrorCode
+	// MalformedURLErrorCode is the error code associated with MalformedURL
+	MalformedURLErrorCode
+
+	//
+	// Customer related error codes start at 1000 and go to 1999
+	//
+
+	// CustTypeConversionErrorCode is the error code associated with CustTypeConversion
+	CustTypeConversionErrorCode = UnableToOpenConfigErrorCode + 1000
+	// CustGETErrorCode is the error code associated with CustGETError
+	CustGETErrorCode
 )


### PR DESCRIPTION
Single customer resource is still not supported (e.g., /customers/{id})